### PR TITLE
Task 001: Deploy MCP server on VPS with Cloudflare Tunnel

### DIFF
--- a/deploy/cloudflared-config.yml
+++ b/deploy/cloudflared-config.yml
@@ -1,0 +1,11 @@
+# Copy to /root/.cloudflared/config.yml on VPS
+# Replace tunnel ID and credentials-file with your actual values
+tunnel: <TUNNEL_ID>
+credentials-file: /root/.cloudflared/<TUNNEL_ID>.json
+
+ingress:
+  - hostname: lunchmoney-mcp.joe-garcia.com
+    service: http://localhost:8090
+    originRequest:
+      noTLSVerify: true
+  - service: http_status:404

--- a/deploy/lunchmoney-mcp.service
+++ b/deploy/lunchmoney-mcp.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Lunch Money MCP Server
+After=network.target
+
+[Service]
+Type=simple
+User=lunchmoney
+Group=lunchmoney
+WorkingDirectory=/opt/lunchmoney-mcp
+ExecStart=/usr/bin/node dist/index.js
+EnvironmentFile=/etc/lunchmoney-mcp/env
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=lunchmoney-mcp
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/tasks/001/progress.md
+++ b/docs/tasks/001/progress.md
@@ -1,0 +1,24 @@
+# Task 001: Deploy MCP server on VPS with Cloudflare Tunnel
+
+## Status: Complete
+
+## Completed Steps
+
+- [x] Node.js 22.22.1 LTS installed via NodeSource
+- [x] `lunchmoney` system user created (uid=999, no login shell)
+- [x] Fork cloned to /opt/lunchmoney-mcp, built successfully
+- [x] Environment file at /etc/lunchmoney-mcp/env (0600, root:root) with LUNCH_MONEY_API_TOKEN, SERVER_API_KEY, PORT=8090
+- [x] systemd unit lunchmoney-mcp.service created (Restart=always, RestartSec=5, runs as lunchmoney user)
+- [x] `systemctl show` does not expose token values (EnvironmentFile used, not Environment)
+- [x] Auto-restart verified: kill process → service restarts within 5 seconds
+- [x] cloudflared 2026.3.0 installed, tunnel `lunchmoney-mcp` created (ID: 6bfee962-36ea-4e1b-9f64-c9c2a2f10c96)
+- [x] DNS CNAME routed: lunchmoney-mcp.joe-garcia.com → tunnel
+- [x] cloudflared systemd service enabled and running
+- [x] Public healthcheck verified: `curl https://lunchmoney-mcp.joe-garcia.com/health` returns 200
+- [x] Auth rejection verified: unauthenticated POST to /mcp returns 401
+
+## Notes
+
+- Port 8080 was already in use by a Python process; using port 8090 instead
+- Tunnel ID: 6bfee962-36ea-4e1b-9f64-c9c2a2f10c96
+- VPS reboot test deferred (would disrupt other services on the VPS)


### PR DESCRIPTION
Closes #3

## Summary
- Deployed lunch-money-mcp on Hetzner VPS (port 8090)
- Node.js 22 LTS, systemd service with auto-restart, non-root `lunchmoney` user
- Secrets in `/etc/lunchmoney-mcp/env` (root:root, 0600)
- Cloudflare Tunnel routing `lunchmoney-mcp.joe-garcia.com` → localhost:8090
- Both `lunchmoney-mcp` and `cloudflared` systemd services enabled

## Verification
- `curl https://lunchmoney-mcp.joe-garcia.com/health` → 200 ✓
- Unauthenticated POST to `/mcp` → 401 ✓
- Kill process → auto-restart within 5s ✓
- `systemctl show` does not expose tokens ✓

## Test plan
- [x] Health endpoint reachable via public URL
- [x] Auth rejection works
- [x] Service auto-restarts on crash
- [ ] VPS reboot test (deferred — would disrupt other services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)