### PR TITLE
Task 011: Backfill tests for user, tags, recurring, budgets, assets, and API client

### DIFF
--- a/tests/api/client.test.ts
+++ b/tests/api/client.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function createJsonResponse(data: unknown, status = 200, ok = true) {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    headers: new Headers({ "content-type": "application/json" }),
+    json: vi.fn().mockResolvedValue(data),
+    text: vi.fn().mockResolvedValue(JSON.stringify(data)),
+  };
+}
+
+function createErrorResponse(
+  status: number,
+  statusText: string,
+  errorBody?: { error: string }
+) {
+  const bodyText = errorBody ? JSON.stringify(errorBody) : statusText;
+  return {
+    ok: false,
+    status,
+    statusText,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: errorBody
+      ? vi.fn().mockResolvedValue(errorBody)
+      : vi.fn().mockRejectedValue(new Error("Not JSON")),
+    text: vi.fn().mockResolvedValue(bodyText),
+  };
+}
+
+describe("LunchMoneyClient", () => {
+  let client: LunchMoneyClient;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    client = new LunchMoneyClient("test-api-token");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("throws if no access token is provided", () => {
+      expect(() => new LunchMoneyClient("")).toThrow(
+        "Lunch Money API token is required"
+      );
+    });
+
+    it("creates client with valid token", () => {
+      const c = new LunchMoneyClient("valid-token");
+      expect(c).toBeInstanceOf(LunchMoneyClient);
+    });
+  });
+
+  describe("get", () => {
+    it("makes GET request without params", async () => {
+      const mockData = { user: { id: 1, name: "Test" } };
+      mockFetch.mockResolvedValue(createJsonResponse(mockData));
+
+      const result = await client.get("/me");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/me",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-api-token",
+            "Content-Type": "application/json",
+          }),
+        })
+      );
+      expect(result).toEqual(mockData);
+    });
+
+    it("makes GET request with params", async () => {
+      const mockData = { transactions: [] };
+      mockFetch.mockResolvedValue(createJsonResponse(mockData));
+
+      await client.get("/transactions", {
+        start_date: "2024-01-01",
+        limit: 10,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/transactions?start_date=2024-01-01&limit=10",
+        expect.objectContaining({ method: "GET" })
+      );
+    });
+
+    it("omits null and undefined params", async () => {
+      const mockData = { transactions: [] };
+      mockFetch.mockResolvedValue(createJsonResponse(mockData));
+
+      await client.get("/transactions", {
+        start_date: "2024-01-01",
+        end_date: undefined,
+        category_id: null,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/transactions?start_date=2024-01-01",
+        expect.objectContaining({ method: "GET" })
+      );
+    });
+  });
+
+  describe("post", () => {
+    it("makes POST request with body", async () => {
+      const mockData = { tag: { id: 1, name: "test" } };
+      mockFetch.mockResolvedValue(createJsonResponse(mockData));
+
+      const result = await client.post("/tags", { name: "test" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/tags",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ name: "test" }),
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-api-token",
+            "Content-Type": "application/json",
+          }),
+        })
+      );
+      expect(result).toEqual(mockData);
+    });
+
+    it("makes POST request without body", async () => {
+      mockFetch.mockResolvedValue(createJsonResponse(true));
+
+      await client.post("/plaid_accounts/fetch");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/plaid_accounts/fetch",
+        expect.objectContaining({
+          method: "POST",
+          body: undefined,
+        })
+      );
+    });
+  });
+
+  describe("put", () => {
+    it("makes PUT request with body", async () => {
+      const mockData = { tag: { id: 1, name: "updated" } };
+      mockFetch.mockResolvedValue(createJsonResponse(mockData));
+
+      const result = await client.put("/tags/1", { name: "updated" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/tags/1",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ name: "updated" }),
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-api-token",
+            "Content-Type": "application/json",
+          }),
+        })
+      );
+      expect(result).toEqual(mockData);
+    });
+
+    it("makes PUT request without body", async () => {
+      mockFetch.mockResolvedValue(createJsonResponse({}));
+
+      await client.put("/tags/1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/tags/1",
+        expect.objectContaining({
+          method: "PUT",
+          body: undefined,
+        })
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("makes DELETE request", async () => {
+      mockFetch.mockResolvedValue(createJsonResponse({}));
+
+      await client.delete("/tags/1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.lunchmoney.app/v1/tags/1",
+        expect.objectContaining({
+          method: "DELETE",
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-api-token",
+            "Content-Type": "application/json",
+          }),
+        })
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws LunchMoneyAPIError with error message from API response", async () => {
+      mockFetch.mockResolvedValue(
+        createErrorResponse(401, "Unauthorized", {
+          error: "Invalid API key",
+        })
+      );
+
+      await expect(client.get("/me")).rejects.toThrow(LunchMoneyAPIError);
+      await expect(client.get("/me")).rejects.toThrow("Invalid API key");
+    });
+
+    it("throws LunchMoneyAPIError with statusText when response is not JSON", async () => {
+      const response = {
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: new Headers({ "content-type": "text/plain" }),
+        json: vi.fn().mockRejectedValue(new Error("Not JSON")),
+        text: vi.fn().mockResolvedValue("Server error"),
+      };
+      mockFetch.mockResolvedValue(response);
+
+      await expect(client.get("/me")).rejects.toThrow(LunchMoneyAPIError);
+      await expect(client.get("/me")).rejects.toThrow(
+        "API request failed: Internal Server Error"
+      );
+    });
+
+    it("throws LunchMoneyAPIError with status code", async () => {
+      mockFetch.mockResolvedValue(
+        createErrorResponse(429, "Too Many Requests", {
+          error: "Rate limited",
+        })
+      );
+
+      try {
+        await client.get("/me");
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(LunchMoneyAPIError);
+        expect((err as LunchMoneyAPIError).statusCode).toBe(429);
+        expect((err as LunchMoneyAPIError).message).toBe("Rate limited");
+      }
+    });
+
+    it("wraps network errors in LunchMoneyAPIError", async () => {
+      mockFetch.mockRejectedValue(new Error("fetch failed"));
+
+      await expect(client.get("/me")).rejects.toThrow(LunchMoneyAPIError);
+      await expect(client.get("/me")).rejects.toThrow("fetch failed");
+    });
+
+    it("wraps non-Error throws in LunchMoneyAPIError", async () => {
+      mockFetch.mockRejectedValue("unexpected string");
+
+      await expect(client.get("/me")).rejects.toThrow(LunchMoneyAPIError);
+      await expect(client.get("/me")).rejects.toThrow(
+        "Unknown error occurred"
+      );
+    });
+
+    it("returns empty object for non-JSON successful response", async () => {
+      const response = {
+        ok: true,
+        status: 204,
+        statusText: "No Content",
+        headers: new Headers({ "content-type": "text/plain" }),
+        json: vi.fn(),
+        text: vi.fn().mockResolvedValue(""),
+      };
+      mockFetch.mockResolvedValue(response);
+
+      const result = await client.delete("/tags/1");
+
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/tests/tools/assets.test.ts
+++ b/tests/tools/assets.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerAssetTools } from "../../src/tools/assets.js";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+import type { AssetsResponse, Asset } from "../../src/types/index.js";
+
+// Capture registered tools via a fake FastMCP server
+interface RegisteredTool {
+  name: string;
+  description: string;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function createMockServer() {
+  const tools: RegisteredTool[] = [];
+  return {
+    addTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    tools,
+  };
+}
+
+function createMockClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as LunchMoneyClient & {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("Asset tools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let tools: RegisteredTool[];
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    mockClient = createMockClient();
+    registerAssetTools(mockServer as never, mockClient);
+    tools = mockServer.tools;
+  });
+
+  it("registers four tools", () => {
+    expect(tools).toHaveLength(4);
+    expect(tools.map((t) => t.name)).toEqual([
+      "getAssets",
+      "createAsset",
+      "updateAsset",
+      "deleteAsset",
+    ]);
+  });
+
+  describe("getAssets", () => {
+    it("returns JSON stringified assets on success", async () => {
+      const mockResponse: AssetsResponse = {
+        assets: [
+          {
+            id: 1,
+            type_name: "cash",
+            name: "Emergency Fund",
+            balance: "10000.00",
+            currency: "usd",
+            institution_name: "Ally Bank",
+            created_at: "2024-01-01T00:00:00.000Z",
+          },
+          {
+            id: 2,
+            type_name: "investment",
+            name: "401k",
+            balance: "50000.00",
+            currency: "usd",
+            institution_name: "Fidelity",
+            created_at: "2024-02-01T00:00:00.000Z",
+          },
+        ],
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "getAssets")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith("/assets");
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Unauthorized", 401)
+      );
+
+      const tool = tools.find((t) => t.name === "getAssets")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Unauthorized (Status: 401)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getAssets")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getAssets")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("createAsset", () => {
+    it("returns JSON stringified asset on success", async () => {
+      const mockResponse: { asset: Asset } = {
+        asset: {
+          id: 3,
+          type_name: "real estate",
+          name: "Home",
+          balance: "350000.00",
+          currency: "usd",
+          created_at: "2024-03-01T00:00:00.000Z",
+        },
+      };
+
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "createAsset")!;
+      const args = {
+        type_name: "real estate",
+        name: "Home",
+        balance: "350000.00",
+      };
+      const result = await tool.execute(args);
+
+      expect(mockClient.post).toHaveBeenCalledWith("/assets", args);
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Bad Request", 400)
+      );
+
+      const tool = tools.find((t) => t.name === "createAsset")!;
+      const result = await tool.execute({
+        type_name: "cash",
+        name: "Savings",
+        balance: "1000.00",
+      });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Bad Request (Status: 400)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection timeout"));
+
+      const tool = tools.find((t) => t.name === "createAsset")!;
+      const result = await tool.execute({
+        type_name: "cash",
+        name: "Savings",
+        balance: "1000.00",
+      });
+
+      expect(result).toBe("Error: Connection timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "createAsset")!;
+      const result = await tool.execute({
+        type_name: "cash",
+        name: "Savings",
+        balance: "1000.00",
+      });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("updateAsset", () => {
+    it("returns JSON stringified updated asset on success", async () => {
+      const mockResponse: { asset: Asset } = {
+        asset: {
+          id: 1,
+          type_name: "cash",
+          name: "Emergency Fund",
+          balance: "12000.00",
+          currency: "usd",
+        },
+      };
+
+      mockClient.put.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "updateAsset")!;
+      const result = await tool.execute({ id: 1, balance: "12000.00" });
+
+      expect(mockClient.put).toHaveBeenCalledWith("/assets/1", {
+        balance: "12000.00",
+      });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.put.mockRejectedValue(
+        new LunchMoneyAPIError("Not Found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "updateAsset")!;
+      const result = await tool.execute({ id: 999, balance: "12000.00" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Not Found (Status: 404)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.put.mockRejectedValue(new Error("Server error"));
+
+      const tool = tools.find((t) => t.name === "updateAsset")!;
+      const result = await tool.execute({ id: 1, balance: "12000.00" });
+
+      expect(result).toBe("Error: Server error");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.put.mockRejectedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "updateAsset")!;
+      const result = await tool.execute({ id: 1, balance: "12000.00" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("deleteAsset", () => {
+    it("returns success message on delete", async () => {
+      mockClient.delete.mockResolvedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "deleteAsset")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(mockClient.delete).toHaveBeenCalledWith("/assets/2");
+      expect(result).toBe("Asset 2 deleted successfully");
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.delete.mockRejectedValue(
+        new LunchMoneyAPIError("Forbidden", 403)
+      );
+
+      const tool = tools.find((t) => t.name === "deleteAsset")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Forbidden (Status: 403)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.delete.mockRejectedValue(new Error("Network issue"));
+
+      const tool = tools.find((t) => t.name === "deleteAsset")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(result).toBe("Error: Network issue");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.delete.mockRejectedValue(null);
+
+      const tool = tools.find((t) => t.name === "deleteAsset")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+});

--- a/tests/tools/budgets.test.ts
+++ b/tests/tools/budgets.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerBudgetTools } from "../../src/tools/budgets.js";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+import type { BudgetsResponse, Budget } from "../../src/types/index.js";
+
+// Capture registered tools via a fake FastMCP server
+interface RegisteredTool {
+  name: string;
+  description: string;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function createMockServer() {
+  const tools: RegisteredTool[] = [];
+  return {
+    addTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    tools,
+  };
+}
+
+function createMockClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as LunchMoneyClient & {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("Budget tools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let tools: RegisteredTool[];
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    mockClient = createMockClient();
+    registerBudgetTools(mockServer as never, mockClient);
+    tools = mockServer.tools;
+  });
+
+  it("registers four tools", () => {
+    expect(tools).toHaveLength(4);
+    expect(tools.map((t) => t.name)).toEqual([
+      "getBudgets",
+      "createBudget",
+      "updateBudget",
+      "deleteBudget",
+    ]);
+  });
+
+  describe("getBudgets", () => {
+    it("returns JSON stringified budgets on success", async () => {
+      const mockResponse: BudgetsResponse = {
+        budgets: [
+          {
+            id: 1,
+            category_id: 10,
+            category_name: "Groceries",
+            amount: "500.00",
+            currency: "usd",
+            start_date: "2024-01-01",
+            end_date: "2024-01-31",
+          },
+          {
+            id: 2,
+            category_id: 20,
+            category_name: "Entertainment",
+            amount: "200.00",
+            currency: "usd",
+            start_date: "2024-01-01",
+            end_date: "2024-01-31",
+          },
+        ],
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "getBudgets")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith("/budgets");
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Unauthorized", 401)
+      );
+
+      const tool = tools.find((t) => t.name === "getBudgets")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Unauthorized (Status: 401)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getBudgets")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getBudgets")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("createBudget", () => {
+    it("returns JSON stringified budget on success", async () => {
+      const mockResponse: { budget: Budget } = {
+        budget: {
+          id: 3,
+          category_id: 30,
+          category_name: "Transport",
+          amount: "150.00",
+          currency: "usd",
+          start_date: "2024-02-01",
+          end_date: "2024-02-29",
+        },
+      };
+
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "createBudget")!;
+      const args = {
+        category_id: 30,
+        amount: "150.00",
+        start_date: "2024-02-01",
+        end_date: "2024-02-29",
+      };
+      const result = await tool.execute(args);
+
+      expect(mockClient.post).toHaveBeenCalledWith("/budgets", args);
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Bad Request", 400)
+      );
+
+      const tool = tools.find((t) => t.name === "createBudget")!;
+      const result = await tool.execute({
+        amount: "150.00",
+        start_date: "2024-02-01",
+        end_date: "2024-02-29",
+      });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Bad Request (Status: 400)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection timeout"));
+
+      const tool = tools.find((t) => t.name === "createBudget")!;
+      const result = await tool.execute({
+        amount: "150.00",
+        start_date: "2024-02-01",
+        end_date: "2024-02-29",
+      });
+
+      expect(result).toBe("Error: Connection timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "createBudget")!;
+      const result = await tool.execute({
+        amount: "150.00",
+        start_date: "2024-02-01",
+        end_date: "2024-02-29",
+      });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("updateBudget", () => {
+    it("returns JSON stringified updated budget on success", async () => {
+      const mockResponse: { budget: Budget } = {
+        budget: {
+          id: 1,
+          category_id: 10,
+          category_name: "Groceries",
+          amount: "600.00",
+          currency: "usd",
+          start_date: "2024-01-01",
+          end_date: "2024-01-31",
+        },
+      };
+
+      mockClient.put.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "updateBudget")!;
+      const result = await tool.execute({ id: 1, amount: "600.00" });
+
+      expect(mockClient.put).toHaveBeenCalledWith("/budgets/1", {
+        amount: "600.00",
+      });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.put.mockRejectedValue(
+        new LunchMoneyAPIError("Not Found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "updateBudget")!;
+      const result = await tool.execute({ id: 999, amount: "600.00" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Not Found (Status: 404)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.put.mockRejectedValue(new Error("Server error"));
+
+      const tool = tools.find((t) => t.name === "updateBudget")!;
+      const result = await tool.execute({ id: 1, amount: "600.00" });
+
+      expect(result).toBe("Error: Server error");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.put.mockRejectedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "updateBudget")!;
+      const result = await tool.execute({ id: 1, amount: "600.00" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("deleteBudget", () => {
+    it("returns success message on delete", async () => {
+      mockClient.delete.mockResolvedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "deleteBudget")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(mockClient.delete).toHaveBeenCalledWith("/budgets/2");
+      expect(result).toBe("Budget 2 deleted successfully");
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.delete.mockRejectedValue(
+        new LunchMoneyAPIError("Forbidden", 403)
+      );
+
+      const tool = tools.find((t) => t.name === "deleteBudget")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Forbidden (Status: 403)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.delete.mockRejectedValue(new Error("Network issue"));
+
+      const tool = tools.find((t) => t.name === "deleteBudget")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(result).toBe("Error: Network issue");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.delete.mockRejectedValue(null);
+
+      const tool = tools.find((t) => t.name === "deleteBudget")!;
+      const result = await tool.execute({ id: 2 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+});

--- a/tests/tools/recurring.test.ts
+++ b/tests/tools/recurring.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerRecurringTools } from "../../src/tools/recurring.js";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+import type {
+  RecurringItemsResponse,
+  RecurringItem,
+} from "../../src/types/index.js";
+
+// Capture registered tools via a fake FastMCP server
+interface RegisteredTool {
+  name: string;
+  description: string;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function createMockServer() {
+  const tools: RegisteredTool[] = [];
+  return {
+    addTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    tools,
+  };
+}
+
+function createMockClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as LunchMoneyClient & {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("Recurring tools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let tools: RegisteredTool[];
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    mockClient = createMockClient();
+    registerRecurringTools(mockServer as never, mockClient);
+    tools = mockServer.tools;
+  });
+
+  it("registers four tools", () => {
+    expect(tools).toHaveLength(4);
+    expect(tools.map((t) => t.name)).toEqual([
+      "getRecurringItems",
+      "createRecurringItem",
+      "updateRecurringItem",
+      "deleteRecurringItem",
+    ]);
+  });
+
+  describe("getRecurringItems", () => {
+    it("returns JSON stringified recurring items on success", async () => {
+      const mockResponse: RecurringItemsResponse = {
+        recurring_items: [
+          {
+            id: 1,
+            payee: "Netflix",
+            amount: "15.99",
+            currency: "usd",
+            frequency: "monthly",
+            flow: "outflow",
+            start_date: "2024-01-01",
+          },
+          {
+            id: 2,
+            payee: "Salary",
+            amount: "5000.00",
+            currency: "usd",
+            frequency: "monthly",
+            flow: "inflow",
+            start_date: "2024-01-15",
+          },
+        ],
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "getRecurringItems")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith("/recurring_expenses");
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Unauthorized", 401)
+      );
+
+      const tool = tools.find((t) => t.name === "getRecurringItems")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Unauthorized (Status: 401)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getRecurringItems")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getRecurringItems")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("createRecurringItem", () => {
+    it("returns JSON stringified recurring item on success", async () => {
+      const mockResponse: { recurring_expense: RecurringItem } = {
+        recurring_expense: {
+          id: 3,
+          payee: "Gym",
+          amount: "50.00",
+          currency: "usd",
+          frequency: "monthly",
+          flow: "outflow",
+          start_date: "2024-03-01",
+        },
+      };
+
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "createRecurringItem")!;
+      const args = { payee: "Gym", amount: "50.00", frequency: "monthly", flow: "outflow", start_date: "2024-03-01" };
+      const result = await tool.execute(args);
+
+      expect(mockClient.post).toHaveBeenCalledWith("/recurring_expenses", args);
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Bad Request", 400)
+      );
+
+      const tool = tools.find((t) => t.name === "createRecurringItem")!;
+      const result = await tool.execute({ amount: "50.00" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Bad Request (Status: 400)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection timeout"));
+
+      const tool = tools.find((t) => t.name === "createRecurringItem")!;
+      const result = await tool.execute({ amount: "50.00" });
+
+      expect(result).toBe("Error: Connection timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "createRecurringItem")!;
+      const result = await tool.execute({ amount: "50.00" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("updateRecurringItem", () => {
+    it("returns JSON stringified updated recurring item on success", async () => {
+      const mockResponse: { recurring_expense: RecurringItem } = {
+        recurring_expense: {
+          id: 1,
+          payee: "Netflix Premium",
+          amount: "22.99",
+          currency: "usd",
+          frequency: "monthly",
+          flow: "outflow",
+        },
+      };
+
+      mockClient.put.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "updateRecurringItem")!;
+      const result = await tool.execute({ id: 1, payee: "Netflix Premium", amount: "22.99" });
+
+      expect(mockClient.put).toHaveBeenCalledWith("/recurring_expenses/1", {
+        payee: "Netflix Premium",
+        amount: "22.99",
+      });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.put.mockRejectedValue(
+        new LunchMoneyAPIError("Not Found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "updateRecurringItem")!;
+      const result = await tool.execute({ id: 999, amount: "22.99" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Not Found (Status: 404)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.put.mockRejectedValue(new Error("Server error"));
+
+      const tool = tools.find((t) => t.name === "updateRecurringItem")!;
+      const result = await tool.execute({ id: 1, amount: "22.99" });
+
+      expect(result).toBe("Error: Server error");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.put.mockRejectedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "updateRecurringItem")!;
+      const result = await tool.execute({ id: 1, amount: "22.99" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("deleteRecurringItem", () => {
+    it("returns success message on delete", async () => {
+      mockClient.delete.mockResolvedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "deleteRecurringItem")!;
+      const result = await tool.execute({ id: 3 });
+
+      expect(mockClient.delete).toHaveBeenCalledWith("/recurring_expenses/3");
+      expect(result).toBe("Recurring item 3 deleted successfully");
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.delete.mockRejectedValue(
+        new LunchMoneyAPIError("Forbidden", 403)
+      );
+
+      const tool = tools.find((t) => t.name === "deleteRecurringItem")!;
+      const result = await tool.execute({ id: 3 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Forbidden (Status: 403)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.delete.mockRejectedValue(new Error("Network issue"));
+
+      const tool = tools.find((t) => t.name === "deleteRecurringItem")!;
+      const result = await tool.execute({ id: 3 });
+
+      expect(result).toBe("Error: Network issue");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.delete.mockRejectedValue(null);
+
+      const tool = tools.find((t) => t.name === "deleteRecurringItem")!;
+      const result = await tool.execute({ id: 3 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+});

--- a/tests/tools/tags.test.ts
+++ b/tests/tools/tags.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerTagTools } from "../../src/tools/tags.js";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+import type { TagsResponse, Tag } from "../../src/types/index.js";
+
+// Capture registered tools via a fake FastMCP server
+interface RegisteredTool {
+  name: string;
+  description: string;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function createMockServer() {
+  const tools: RegisteredTool[] = [];
+  return {
+    addTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    tools,
+  };
+}
+
+function createMockClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as LunchMoneyClient & {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("Tag tools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let tools: RegisteredTool[];
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    mockClient = createMockClient();
+    registerTagTools(mockServer as never, mockClient);
+    tools = mockServer.tools;
+  });
+
+  it("registers four tools", () => {
+    expect(tools).toHaveLength(4);
+    expect(tools.map((t) => t.name)).toEqual([
+      "getTags",
+      "createTag",
+      "updateTag",
+      "deleteTag",
+    ]);
+  });
+
+  describe("getTags", () => {
+    it("returns JSON stringified tags on success", async () => {
+      const mockResponse: TagsResponse = {
+        tags: [
+          { id: 1, name: "groceries", created_at: "2024-01-01T00:00:00.000Z" },
+          { id: 2, name: "travel", created_at: "2024-02-01T00:00:00.000Z" },
+        ],
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "getTags")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith("/tags");
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Unauthorized", 401)
+      );
+
+      const tool = tools.find((t) => t.name === "getTags")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Unauthorized (Status: 401)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getTags")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getTags")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("createTag", () => {
+    it("returns JSON stringified tag on success", async () => {
+      const mockResponse: { tag: Tag } = {
+        tag: { id: 3, name: "utilities", created_at: "2024-03-01T00:00:00.000Z" },
+      };
+
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "createTag")!;
+      const result = await tool.execute({ name: "utilities" });
+
+      expect(mockClient.post).toHaveBeenCalledWith("/tags", { name: "utilities" });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Bad Request", 400)
+      );
+
+      const tool = tools.find((t) => t.name === "createTag")!;
+      const result = await tool.execute({ name: "utilities" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Bad Request (Status: 400)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection timeout"));
+
+      const tool = tools.find((t) => t.name === "createTag")!;
+      const result = await tool.execute({ name: "utilities" });
+
+      expect(result).toBe("Error: Connection timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "createTag")!;
+      const result = await tool.execute({ name: "utilities" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("updateTag", () => {
+    it("returns JSON stringified updated tag on success", async () => {
+      const mockResponse: { tag: Tag } = {
+        tag: { id: 1, name: "food", created_at: "2024-01-01T00:00:00.000Z" },
+      };
+
+      mockClient.put.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "updateTag")!;
+      const result = await tool.execute({ id: 1, name: "food" });
+
+      expect(mockClient.put).toHaveBeenCalledWith("/tags/1", { name: "food" });
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.put.mockRejectedValue(
+        new LunchMoneyAPIError("Not Found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "updateTag")!;
+      const result = await tool.execute({ id: 999, name: "food" });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Not Found (Status: 404)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.put.mockRejectedValue(new Error("Server error"));
+
+      const tool = tools.find((t) => t.name === "updateTag")!;
+      const result = await tool.execute({ id: 1, name: "food" });
+
+      expect(result).toBe("Error: Server error");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.put.mockRejectedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "updateTag")!;
+      const result = await tool.execute({ id: 1, name: "food" });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  describe("deleteTag", () => {
+    it("returns success message on delete", async () => {
+      mockClient.delete.mockResolvedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "deleteTag")!;
+      const result = await tool.execute({ id: 5 });
+
+      expect(mockClient.delete).toHaveBeenCalledWith("/tags/5");
+      expect(result).toBe("Tag 5 deleted successfully");
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.delete.mockRejectedValue(
+        new LunchMoneyAPIError("Forbidden", 403)
+      );
+
+      const tool = tools.find((t) => t.name === "deleteTag")!;
+      const result = await tool.execute({ id: 5 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Forbidden (Status: 403)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.delete.mockRejectedValue(new Error("Network issue"));
+
+      const tool = tools.find((t) => t.name === "deleteTag")!;
+      const result = await tool.execute({ id: 5 });
+
+      expect(result).toBe("Error: Network issue");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.delete.mockRejectedValue(null);
+
+      const tool = tools.find((t) => t.name === "deleteTag")!;
+      const result = await tool.execute({ id: 5 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+});

--- a/tests/tools/user.test.ts
+++ b/tests/tools/user.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerUserTools } from "../../src/tools/user.js";
+import { LunchMoneyClient } from "../../src/api/client.js";
+import { LunchMoneyAPIError } from "../../src/utils/errors.js";
+import type { User } from "../../src/types/index.js";
+
+// Capture registered tools via a fake FastMCP server
+interface RegisteredTool {
+  name: string;
+  description: string;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function createMockServer() {
+  const tools: RegisteredTool[] = [];
+  return {
+    addTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    tools,
+  };
+}
+
+function createMockClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as LunchMoneyClient & {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("User tools", () => {
+  let mockServer: ReturnType<typeof createMockServer>;
+  let mockClient: ReturnType<typeof createMockClient>;
+  let tools: RegisteredTool[];
+
+  beforeEach(() => {
+    mockServer = createMockServer();
+    mockClient = createMockClient();
+    registerUserTools(mockServer as never, mockClient);
+    tools = mockServer.tools;
+  });
+
+  it("registers one tool", () => {
+    expect(tools).toHaveLength(1);
+    expect(tools.map((t) => t.name)).toEqual(["getUser"]);
+  });
+
+  describe("getUser", () => {
+    it("returns JSON stringified user on success", async () => {
+      const mockUser: User = {
+        id: 1,
+        email: "test@example.com",
+        name: "Test User",
+        currency: "usd",
+        budget_display_order: [1, 2, 3],
+        date_format: "MM/DD/YYYY",
+        first_day_of_week: 0,
+        beta_user: false,
+        created_at: "2024-01-01T00:00:00.000Z",
+      };
+
+      mockClient.get.mockResolvedValue(mockUser);
+
+      const tool = tools.find((t) => t.name === "getUser")!;
+      const result = await tool.execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith("/me");
+      expect(result).toBe(JSON.stringify(mockUser, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Unauthorized", 401)
+      );
+
+      const tool = tools.find((t) => t.name === "getUser")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe(
+        "Lunch Money API Error: Unauthorized (Status: 401)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getUser")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getUser")!;
+      const result = await tool.execute({});
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+});


### PR DESCRIPTION
Closes #20

## Summary
- Add test suites for `user`, `tags`, `recurring`, `budgets`, `assets` tools and the `LunchMoneyClient` API client
- All tests follow the established `plaid.test.ts` pattern: mock client, register tools via fake FastMCP server, assert JSON output for success and formatted error strings for failures
- API client tests mock `fetch` to cover GET/POST/PUT/DELETE methods, query parameter handling, error responses, and network failures
- **98 tests total, all passing**
- Coverage: 100% on all tested tool files, 96.87% on `client.ts`, 92.85% on `errors.ts`

## Test plan
- [x] `npm run build` compiles successfully
- [x] `npm test` — all 98 tests pass (7 test files)
- [x] `npm run test:coverage` — coverage >90% for all files under test
- [x] No source files modified — tests only