### PR TITLE
Task 009: Transaction grouping and unsplit tools with tests

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -151,6 +151,20 @@ export const updateAssetSchema = z.object({
   institution_name: z.string().optional(),
 });
 
+// Transaction group schemas
+export const createTransactionGroupSchema = z.object({
+  date: z.string(),
+  payee: z.string(),
+  transactions: z.array(z.number()).min(2),
+  category_id: z.number().optional(),
+  notes: z.string().optional(),
+  tags: z.array(z.number()).optional(),
+});
+
+export const unsplitTransactionsSchema = z.object({
+  parent_ids: z.array(z.number()).min(1),
+});
+
 // Category group schemas
 export const createCategoryGroupSchema = z.object({
   name: z.string().min(1),

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -7,6 +7,8 @@ import {
   createTransactionSchema,
   updateTransactionSchema,
   bulkUpdateTransactionsSchema,
+  createTransactionGroupSchema,
+  unsplitTransactionsSchema,
   idSchema,
 } from "../schemas/index.js";
 import { TransactionsResponse, Transaction } from "../types/index.js";
@@ -110,6 +112,70 @@ export function registerTransactionTools(
           args
         );
         return JSON.stringify(result, null, 2);
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+
+  server.addTool({
+    name: "getTransactionGroup",
+    description: "Retrieve a transaction group with all child transactions",
+    parameters: idSchema,
+    execute: async (args: z.infer<typeof idSchema>) => {
+      try {
+        const response = await client.get<Transaction>(
+          `/transactions/group/${args.id}`
+        );
+        return JSON.stringify(response, null, 2);
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+
+  server.addTool({
+    name: "createTransactionGroup",
+    description:
+      "Group multiple transaction IDs under a single parent transaction",
+    parameters: createTransactionGroupSchema,
+    execute: async (args: z.infer<typeof createTransactionGroupSchema>) => {
+      try {
+        const response = await client.post<Transaction>(
+          "/transactions/group",
+          args
+        );
+        return JSON.stringify(response, null, 2);
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+
+  server.addTool({
+    name: "deleteTransactionGroup",
+    description:
+      "Delete a transaction group, restoring individual transactions",
+    parameters: idSchema,
+    execute: async (args: z.infer<typeof idSchema>) => {
+      try {
+        await client.delete(`/transactions/group/${args.id}`);
+        return `Transaction group ${args.id} deleted successfully`;
+      } catch (error) {
+        return formatErrorForMCP(error);
+      }
+    },
+  });
+
+  server.addTool({
+    name: "unsplitTransactions",
+    description:
+      "Reverse a split, merging child transactions back into parent",
+    parameters: unsplitTransactionsSchema,
+    execute: async (args: z.infer<typeof unsplitTransactionsSchema>) => {
+      try {
+        const response = await client.post("/transactions/unsplit", args);
+        return JSON.stringify(response, null, 2);
       } catch (error) {
         return formatErrorForMCP(error);
       }

--- a/tests/tools/transactions.test.ts
+++ b/tests/tools/transactions.test.ts
@@ -63,8 +63,8 @@ describe("Transaction tools", () => {
     tools = mockServer.tools;
   });
 
-  it("registers six tools", () => {
-    expect(tools).toHaveLength(6);
+  it("registers ten tools", () => {
+    expect(tools).toHaveLength(10);
     expect(tools.map((t) => t.name)).toEqual([
       "getTransactions",
       "getTransaction",
@@ -72,6 +72,10 @@ describe("Transaction tools", () => {
       "updateTransaction",
       "deleteTransaction",
       "bulkUpdateTransactions",
+      "getTransactionGroup",
+      "createTransactionGroup",
+      "deleteTransactionGroup",
+      "unsplitTransactions",
     ]);
   });
 
@@ -255,6 +259,227 @@ describe("Transaction tools", () => {
       expect(result).toBe(
         "Lunch Money API Error: Server error (Status: 500)"
       );
+    });
+  });
+
+  // ---------- getTransactionGroup ----------
+  describe("getTransactionGroup", () => {
+    it("returns JSON stringified transaction group on success", async () => {
+      const groupTransaction: Transaction = {
+        ...sampleTransaction,
+        is_group: true,
+        subtransactions: [
+          { ...sampleTransaction, id: 2, group_id: 1 },
+          { ...sampleTransaction, id: 3, group_id: 1 },
+        ],
+      };
+      mockClient.get.mockResolvedValue(groupTransaction);
+
+      const tool = tools.find((t) => t.name === "getTransactionGroup")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(mockClient.get).toHaveBeenCalledWith("/transactions/group/1");
+      expect(result).toBe(JSON.stringify(groupTransaction, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.get.mockRejectedValue(
+        new LunchMoneyAPIError("Group not found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "getTransactionGroup")!;
+      const result = await tool.execute({ id: 99999 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Group not found (Status: 404)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.get.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "getTransactionGroup")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.get.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "getTransactionGroup")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  // ---------- createTransactionGroup ----------
+  describe("createTransactionGroup", () => {
+    it("returns JSON stringified group transaction on success", async () => {
+      const groupTransaction: Transaction = {
+        ...sampleTransaction,
+        is_group: true,
+        subtransactions: [
+          { ...sampleTransaction, id: 2, group_id: 1 },
+          { ...sampleTransaction, id: 3, group_id: 1 },
+        ],
+      };
+      mockClient.post.mockResolvedValue(groupTransaction);
+
+      const tool = tools.find((t) => t.name === "createTransactionGroup")!;
+      const args = {
+        date: "2024-06-01",
+        payee: "Grouped Transaction",
+        transactions: [2, 3],
+        category_id: 10,
+        notes: "Grouped for tracking",
+      };
+      const result = await tool.execute(args);
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "/transactions/group",
+        args
+      );
+      expect(result).toBe(JSON.stringify(groupTransaction, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Validation error", 422)
+      );
+
+      const tool = tools.find((t) => t.name === "createTransactionGroup")!;
+      const result = await tool.execute({
+        date: "2024-06-01",
+        payee: "Bad Group",
+        transactions: [2, 3],
+      });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Validation error (Status: 422)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection timeout"));
+
+      const tool = tools.find((t) => t.name === "createTransactionGroup")!;
+      const result = await tool.execute({
+        date: "2024-06-01",
+        payee: "Group",
+        transactions: [2, 3],
+      });
+
+      expect(result).toBe("Error: Connection timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "createTransactionGroup")!;
+      const result = await tool.execute({
+        date: "2024-06-01",
+        payee: "Group",
+        transactions: [2, 3],
+      });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  // ---------- deleteTransactionGroup ----------
+  describe("deleteTransactionGroup", () => {
+    it("returns success message on delete", async () => {
+      mockClient.delete.mockResolvedValue(undefined);
+
+      const tool = tools.find((t) => t.name === "deleteTransactionGroup")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(mockClient.delete).toHaveBeenCalledWith(
+        "/transactions/group/1"
+      );
+      expect(result).toBe("Transaction group 1 deleted successfully");
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.delete.mockRejectedValue(
+        new LunchMoneyAPIError("Group not found", 404)
+      );
+
+      const tool = tools.find((t) => t.name === "deleteTransactionGroup")!;
+      const result = await tool.execute({ id: 99999 });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Group not found (Status: 404)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.delete.mockRejectedValue(new Error("Network failure"));
+
+      const tool = tools.find((t) => t.name === "deleteTransactionGroup")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(result).toBe("Error: Network failure");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.delete.mockRejectedValue("something unexpected");
+
+      const tool = tools.find((t) => t.name === "deleteTransactionGroup")!;
+      const result = await tool.execute({ id: 1 });
+
+      expect(result).toBe("An unknown error occurred");
+    });
+  });
+
+  // ---------- unsplitTransactions ----------
+  describe("unsplitTransactions", () => {
+    it("returns JSON stringified response on success", async () => {
+      const mockResponse = { parent_ids: [1], transactions: [sampleTransaction] };
+      mockClient.post.mockResolvedValue(mockResponse);
+
+      const tool = tools.find((t) => t.name === "unsplitTransactions")!;
+      const args = { parent_ids: [1] };
+      const result = await tool.execute(args);
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        "/transactions/unsplit",
+        args
+      );
+      expect(result).toBe(JSON.stringify(mockResponse, null, 2));
+    });
+
+    it("returns formatted error on LunchMoneyAPIError", async () => {
+      mockClient.post.mockRejectedValue(
+        new LunchMoneyAPIError("Cannot unsplit", 400)
+      );
+
+      const tool = tools.find((t) => t.name === "unsplitTransactions")!;
+      const result = await tool.execute({ parent_ids: [99999] });
+
+      expect(result).toBe(
+        "Lunch Money API Error: Cannot unsplit (Status: 400)"
+      );
+    });
+
+    it("returns formatted error on generic Error", async () => {
+      mockClient.post.mockRejectedValue(new Error("Connection timeout"));
+
+      const tool = tools.find((t) => t.name === "unsplitTransactions")!;
+      const result = await tool.execute({ parent_ids: [1] });
+
+      expect(result).toBe("Error: Connection timeout");
+    });
+
+    it("returns unknown error message for non-Error throws", async () => {
+      mockClient.post.mockRejectedValue(42);
+
+      const tool = tools.find((t) => t.name === "unsplitTransactions")!;
+      const result = await tool.execute({ parent_ids: [1] });
+
+      expect(result).toBe("An unknown error occurred");
     });
   });
 });


### PR DESCRIPTION
Closes #18

## Summary

- Add `createTransactionGroup`, `getTransactionGroup`, `deleteTransactionGroup`, and `unsplitTransactions` tools to the transactions module
- Add `createTransactionGroupSchema` and `unsplitTransactionsSchema` Zod schemas
- Extend transaction tests with success and error cases for all 4 new tools (16 new tests)
- 100% line coverage on `src/tools/transactions.ts`

## Test plan

- [x] `npm run build` compiles without errors
- [x] `npm test` — all 68 tests pass across 3 test files
- [x] Coverage: transactions.ts at 100% stmts/branch/funcs/lines