### PR TITLE
Fix API validation findings from pre-upstream audit

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -163,17 +163,24 @@ export const createTransactionGroupSchema = z.object({
 
 export const unsplitTransactionsSchema = z.object({
   parent_ids: z.array(z.number()).min(1),
+  remove_parents: z.boolean().optional(),
 });
 
 // Category group schemas
 export const createCategoryGroupSchema = z.object({
   name: z.string().min(1),
+  description: z.string().optional(),
+  is_income: z.boolean().optional(),
+  exclude_from_budget: z.boolean().optional(),
+  exclude_from_totals: z.boolean().optional(),
   category_ids: z.array(z.number()).optional(),
+  new_categories: z.array(z.string()).optional(),
 });
 
 export const addToGroupSchema = z.object({
   group_id: z.number().int().positive(),
-  category_ids: z.array(z.number()).min(1),
+  category_ids: z.array(z.number()).optional(),
+  new_categories: z.array(z.string()).optional(),
 });
 
 // ID parameter schemas

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -125,7 +125,8 @@ export function registerTransactionTools(
     execute: async (args: z.infer<typeof idSchema>) => {
       try {
         const response = await client.get<Transaction>(
-          `/transactions/group/${args.id}`
+          "/transactions/group",
+          { transaction_id: args.id }
         );
         return JSON.stringify(response, null, 2);
       } catch (error) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -174,6 +174,14 @@ export interface PlaidAccount {
     currency: string;
     balance_last_update: string;
     limit?: number;
+    plaid_item_id?: number;
+    linked_by_name?: string;
+    allow_transaction_modifications?: boolean;
+    to_base?: number;
+    import_start_date?: string;
+    last_import?: string;
+    last_fetch?: string;
+    plaid_last_successful_update?: string;
 }
 
 export interface PlaidAccountsResponse {

--- a/tests/tools/transactions.test.ts
+++ b/tests/tools/transactions.test.ts
@@ -278,7 +278,7 @@ describe("Transaction tools", () => {
       const tool = tools.find((t) => t.name === "getTransactionGroup")!;
       const result = await tool.execute({ id: 1 });
 
-      expect(mockClient.get).toHaveBeenCalledWith("/transactions/group/1");
+      expect(mockClient.get).toHaveBeenCalledWith("/transactions/group", { transaction_id: 1 });
       expect(result).toBe(JSON.stringify(groupTransaction, null, 2));
     });
 


### PR DESCRIPTION
## Summary

Fixes 1 critical and 4 non-critical issues found during the pre-Task 012 validation audit.

### Critical
- **getTransactionGroup**: Changed from path param (`GET /transactions/group/:id`) to query param (`GET /transactions/group?transaction_id=X`) to match v1 API spec. Previous implementation would return 404 at runtime.

### Non-critical (missing optional parameters)
- **unsplitTransactionsSchema**: Added optional `remove_parents` boolean
- **createCategoryGroupSchema**: Added optional `description`, `is_income`, `exclude_from_budget`, `exclude_from_totals`, `new_categories`
- **addToGroupSchema**: Added optional `new_categories`, made `category_ids` optional (matching API spec)
- **PlaidAccount type**: Added 8 missing optional fields from official API response

### Test plan
- [x] `npm run build` — clean compilation
- [x] `npm test` — 157/157 tests pass
- [x] Test updated to assert query param call pattern for getTransactionGroup

🤖 Generated with [Claude Code](https://claude.com/claude-code)